### PR TITLE
Auto-deploy every PR to a Firebase preview channel

### DIFF
--- a/.github/actions/setup-and-build/action.yaml
+++ b/.github/actions/setup-and-build/action.yaml
@@ -1,0 +1,48 @@
+name: Set up environment and build site
+description: |
+  Install Python and Node tooling, run tests, build the static site
+  into out/, and install the Firebase CLI so the caller can deploy.
+
+inputs:
+  calendar_api_key:
+    description: Google Calendar API key embedded in the frontpage at build time.
+    required: true
+
+runs:
+  using: composite
+  steps:
+    - name: Set up Python
+      uses: actions/setup-python@v5
+      with:
+        python-version: '3.11'
+
+    - name: Install uv
+      uses: astral-sh/setup-uv@v4
+
+    - name: Install Python dependencies
+      shell: bash
+      run: uv sync
+
+    - name: Create private config file
+      shell: bash
+      run: |
+        cat > private_gen_vars.yaml << EOF
+        calendar_api_key: ${{ inputs.calendar_api_key }}
+        EOF
+
+    - name: Run tests
+      shell: bash
+      run: uv run python manage.py test
+
+    - name: Build site
+      shell: bash
+      run: uv run bash build.sh
+
+    - name: Set up Node.js
+      uses: actions/setup-node@v4
+      with:
+        node-version: '20'
+
+    - name: Install Firebase CLI
+      shell: bash
+      run: npm install -g firebase-tools

--- a/.github/workflows/preview.yaml
+++ b/.github/workflows/preview.yaml
@@ -1,0 +1,104 @@
+name: Deploy preview channel
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
+  workflow_dispatch:
+    inputs:
+      channel_id:
+        description: 'Preview channel name (URL slug). Defaults to branch name.'
+        required: false
+      expires:
+        description: 'Channel expiration (e.g. 1h, 7d, 30d)'
+        required: false
+        default: '7d'
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  deploy-preview:
+    name: Build and deploy preview
+    if: >-
+      github.event_name == 'workflow_dispatch' ||
+      (github.event.pull_request.draft == false &&
+       github.event.pull_request.head.repo.full_name == github.repository)
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up environment and build site
+        uses: ./.github/actions/setup-and-build
+        with:
+          calendar_api_key: ${{ secrets.CALENDAR_API_KEY }}
+
+      - name: Compute channel id
+        id: channel
+        run: |
+          INPUT_ID="${{ github.event.inputs.channel_id }}"
+          if [ -n "$INPUT_ID" ]; then
+            RAW="$INPUT_ID"
+          elif [ -n "${{ github.head_ref }}" ]; then
+            RAW="${{ github.head_ref }}"
+          else
+            RAW="${{ github.ref_name }}"
+          fi
+          # Firebase channel ids: lowercase letters, digits, hyphens, underscores; max 63 chars.
+          SAFE=$(echo "$RAW" | tr '[:upper:]' '[:lower:]' | tr -c 'a-z0-9_-' '-' | cut -c1-63)
+          echo "id=$SAFE" >> "$GITHUB_OUTPUT"
+
+      - name: Deploy to Firebase preview channel
+        id: deploy
+        env:
+          FIREBASE_TOKEN: ${{ secrets.FIREBASE_TOKEN }}
+        run: |
+          OUTPUT=$(firebase hosting:channel:deploy "${{ steps.channel.outputs.id }}" \
+            --project piosenka-site \
+            --token "$FIREBASE_TOKEN" \
+            --expires "${{ github.event.inputs.expires || '7d' }}" \
+            --json)
+          echo "$OUTPUT"
+          URL=$(echo "$OUTPUT" | jq -r '.result | to_entries[0].value.url')
+          echo "url=$URL" >> "$GITHUB_OUTPUT"
+
+      - name: Post preview link as PR comment
+        if: steps.deploy.outputs.url != ''
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          BRANCH: ${{ github.head_ref || github.ref_name }}
+          URL: ${{ steps.deploy.outputs.url }}
+          EXPIRES: ${{ github.event.inputs.expires || '7d' }}
+        run: |
+          if [ -n "$PR_NUMBER" ]; then
+            PR="$PR_NUMBER"
+          else
+            PR=$(gh pr list --repo "$REPO" --head "$BRANCH" --state open --json number --jq '.[0].number // empty')
+          fi
+          if [ -z "$PR" ]; then
+            echo "No open PR for branch $BRANCH; skipping comment."
+            exit 0
+          fi
+
+          MARKER="<!-- firebase-preview-channel -->"
+          BODY="$MARKER
+          Preview channel deployed for \`$BRANCH\`:
+
+          $URL
+
+          (expires in $EXPIRES; pushing more commits to this branch refreshes the preview)"
+
+          EXISTING=$(gh api "repos/$REPO/issues/$PR/comments" \
+            --jq "[.[] | select(.body | startswith(\"$MARKER\"))][0].id // empty")
+
+          if [ -n "$EXISTING" ]; then
+            gh api -X PATCH "repos/$REPO/issues/comments/$EXISTING" -f body="$BODY" > /dev/null
+            echo "Updated existing preview comment on PR #$PR"
+          else
+            gh pr comment "$PR" --repo "$REPO" --body "$BODY"
+            echo "Posted new preview comment on PR #$PR"
+          fi

--- a/.github/workflows/preview.yaml
+++ b/.github/workflows/preview.yaml
@@ -17,6 +17,10 @@ permissions:
   contents: read
   pull-requests: write
 
+concurrency:
+  group: preview-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   deploy-preview:
     name: Build and deploy preview
@@ -25,6 +29,7 @@ jobs:
       (github.event.pull_request.draft == false &&
        github.event.pull_request.head.repo.full_name == github.repository)
     runs-on: ubuntu-latest
+    timeout-minutes: 15
 
     steps:
       - name: Checkout code

--- a/.github/workflows/preview.yaml
+++ b/.github/workflows/preview.yaml
@@ -37,14 +37,16 @@ jobs:
 
       - name: Compute channel id
         id: channel
+        env:
+          INPUT_ID: ${{ github.event.inputs.channel_id }}
+          HEAD_REF: ${{ github.head_ref }}
         run: |
-          INPUT_ID="${{ github.event.inputs.channel_id }}"
           if [ -n "$INPUT_ID" ]; then
             RAW="$INPUT_ID"
-          elif [ -n "${{ github.head_ref }}" ]; then
-            RAW="${{ github.head_ref }}"
+          elif [ -n "$HEAD_REF" ]; then
+            RAW="$HEAD_REF"
           else
-            RAW="${{ github.ref_name }}"
+            RAW="$GITHUB_REF_NAME"
           fi
           # Firebase channel ids: lowercase letters, digits, hyphens, underscores; max 63 chars.
           SAFE=$(echo "$RAW" | tr '[:upper:]' '[:lower:]' | tr -c 'a-z0-9_-' '-' | cut -c1-63)
@@ -54,11 +56,13 @@ jobs:
         id: deploy
         env:
           FIREBASE_TOKEN: ${{ secrets.FIREBASE_TOKEN }}
+          CHANNEL_ID: ${{ steps.channel.outputs.id }}
+          EXPIRES: ${{ github.event.inputs.expires || '7d' }}
         run: |
-          OUTPUT=$(firebase hosting:channel:deploy "${{ steps.channel.outputs.id }}" \
+          OUTPUT=$(firebase hosting:channel:deploy "$CHANNEL_ID" \
             --project piosenka-site \
             --token "$FIREBASE_TOKEN" \
-            --expires "${{ github.event.inputs.expires || '7d' }}" \
+            --expires "$EXPIRES" \
             --json)
           echo "$OUTPUT"
           URL=$(echo "$OUTPUT" | jq -r '.result | to_entries[0].value.url')

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -14,36 +14,10 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
-      - name: Set up Python
-        uses: actions/setup-python@v5
+      - name: Set up environment and build site
+        uses: ./.github/actions/setup-and-build
         with:
-          python-version: '3.11'
-
-      - name: Install uv
-        uses: astral-sh/setup-uv@v4
-
-      - name: Install Python dependencies
-        run: uv sync
-
-      - name: Create private config file
-        run: |
-          cat > private_gen_vars.yaml << EOF
           calendar_api_key: ${{ secrets.CALENDAR_API_KEY }}
-          EOF
-
-      - name: Run tests
-        run: uv run python manage.py test
-
-      - name: Build site
-        run: uv run bash build.sh
-
-      - name: Set up Node.js
-        uses: actions/setup-node@v4
-        with:
-          node-version: '20'
-
-      - name: Install Firebase CLI
-        run: npm install -g firebase-tools
 
       - name: Publish to Firebase
         env:


### PR DESCRIPTION
This PR adds a workflow that deploys a Firebase Hosting preview channel for every pull request.

Firebase has built-in support for this — each PR gets its own URL like `https://piosenka-site--<branch>-<hash>.web.app`, which expires after 7 days.

The goal is to make reviewing changes easier. Open the URL, see the site running with the branch applied — no local checkout needed.


## How it works

- Open a PR (or push to an already-open PR) → workflow builds the site and deploys to a preview channel named after the branch.

- Same PR pushed again → same channel, same URL, updated content.

- The workflow posts a sticky comment on the PR with the preview link. The comment is updated in place on subsequent pushes (no spam).

- Draft PRs are skipped — preview kicks in once the PR is marked ready for review.

- A "Run workflow" button in the Actions tab also lets you trigger a preview for any branch with a custom channel name and expiration.


## Refactor

Build steps shared with `publish.yaml` are extracted into a composite action at `.github/actions/build-site`, so the two workflows don't duplicate ~25 lines. `publish.yaml` just calls the composite now — no behavior change.


## Security

Safe to merge — no secret leak risk from external PRs:

- Uses `pull_request` (not `pull_request_target`), so PRs from forks run without access to repo secrets. A malicious PR can't read `FIREBASE_TOKEN`.

- Workflow file always runs from the base branch (`main`), not from the PR head. Contributors can't swap in their own workflow.

- Fork PRs are skipped entirely — they'd fail at deploy anyway (no secret access), so we don't waste a CI run.


## Cost

- Firebase Spark (free) tier: 50 preview channels, 10 GB storage, 10 GB/month transfer. Reuses the existing `FIREBASE_TOKEN` secret.

- GitHub Actions minutes are free for public repos.

So no new secrets and no expected cost at this repo's scale.